### PR TITLE
gateway en forests ip/port apart configureerbaar maken

### DIFF
--- a/api-gateway/index.js
+++ b/api-gateway/index.js
@@ -14,7 +14,7 @@ app.use((req, res) => {
     res.status(404).send("Hé, deze endpoint bestaat niet!");
 });
 
-const port = parseInt(process.env.PORT, 10) || 3011;
+const port = parseInt(process.env.GATEWAY_PORT, 10) || 3011;
 
 app.listen(port, () => {
     console.log(`🍿 Express running → PORT ${port}`);

--- a/api-gateway/routes/index.js
+++ b/api-gateway/routes/index.js
@@ -3,8 +3,11 @@ const { createProxyMiddleware, fixRequestBody } = require("http-proxy-middleware
 
 const router = Express.Router();
 
+const forests_port = parseInt(process.env.FORESTS_PORT, 10) || 3012;
+const forests_ip = parseInt(process.env.FORESTS_IP, 10) || "forests";
+
 const forestProxyMiddleware = createProxyMiddleware({
-    target: 'http://forests:3012/',
+    target: `http://${forests_ip}:${forests_port}/`,
     on: {
         proxyReq: fixRequestBody,
     },

--- a/forests/index.js
+++ b/forests/index.js
@@ -21,7 +21,7 @@ app.use((req, res) => {
 
 app.use(errorHandler);
 
-const port = parseInt(process.env.PORT, 10) || 3012;
+const port = parseInt(process.env.FORESTS_PORT, 10) || 3012;
 
 app.listen(port, () => {
     console.log(`🍿 Express running → PORT ${port}`);


### PR DESCRIPTION
Voor als je geen docker gebruikt (bijv. voor deployment op bijv. render of vercel ofz.)